### PR TITLE
Remove border between lesson title/description and standards codes

### DIFF
--- a/edumap/app/assets/stylesheets/lessons.scss
+++ b/edumap/app/assets/stylesheets/lessons.scss
@@ -10,6 +10,10 @@ tr.selected {
   background-color: #DDEFE4;
 }
 
+tr.accordion-body td {
+  border-top: none !important;
+}
+
 tr.accordion-toggle td:last-child {
   text-align: center;
 }


### PR DESCRIPTION
Issue #99 

Using CSS `!important` is not really the best way to do this, but because of the way we have the stylesheets set up (not using `@import`) this is the only way I could think of to override the default Bootstrap styles.

![lesson_list_screenshot2](https://cloud.githubusercontent.com/assets/8214544/16603925/b2b2aabc-42e5-11e6-8056-f1e358920dfb.jpg)
