### PR TITLE
fix Reset Filter button to hide defualt results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'js-routes'
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks'
+# Make JS event-handlers work with Turbolinks behavior
+gem 'jquery-turbolinks'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     js-routes (1.2.4)
       railties (>= 3.2)
       sprockets-rails
@@ -269,6 +272,7 @@ DEPENDENCIES
   haml-rails
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   js-routes
   launchy
   pg

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.turbolinks
 //= require bootstrap-sprockets
 //= require jquery_ujs
 //= require turbolinks
@@ -53,4 +54,8 @@ $(document).ready(function() {
     $('#grFilter').change(handleTableClass);
     $('#compReq').change(handleTableClass);
     $('#sortOrder').change(handleTableClass);
+
+    $('aside.filter-frame').on('click', '#wipe-results', function(){
+      tableResults.classList.add('hidden-table');
+    });
 });


### PR DESCRIPTION
Added gem 'jquery-turbolinks' so that jQuery event handlers work with Turbolinks - for stability. Simply made event handler that adds the 'hidden-table' class back to the table when the 'Reset Button' is clicked.