### PR TITLE
Disable auto-filtering

### DIFF
--- a/app/views/lessons/index.html.haml
+++ b/app/views/lessons/index.html.haml
@@ -1,7 +1,7 @@
 .container-fluid
   .row
     %aside{class: "col-md-3 filter-frame"}
-      = form_for_filterrific @filterrific, html: {class: "filter col-md-12" } do |f|
+      = form_for_filterrific @filterrific, remote: true, html: { class: "filter col-md-12", id: 'filterrific-no-ajax-auto-submit' } do |f|
         .row
           .form-group.chardin_box{ :'data-position' => 'top', :'data-intro' => 'Search lessons.' }
             %label Search
@@ -40,6 +40,9 @@
                        @filterrific.select_options[:sorted_by],
                        {},
                        { :class => 'form-control', :id => 'sortOrder' }
+        .row
+          .form-group
+            = f.submit 'Submit', {:class => 'btn btn-green btn-sm'}
     %div{class: "col-md-9 main-content"}
       #entry-text
         %h1 Welcome to EduMap!


### PR DESCRIPTION
Addresses #128  Form behavior is the same, except users now need to click "Submit" in order for results to be updated. It's still updated without a full page reload through. Screenshot below

![screen shot 2016-12-16 at 8 12 13 pm](https://cloud.githubusercontent.com/assets/8291663/21283673/0fcc798c-c3cc-11e6-9ed3-3d1025032282.png)
